### PR TITLE
解析时in 缺失

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -412,6 +412,7 @@ func (p *parser) newAssignmentStmt(l, r *ast.Node, op Item) *ast.Node {
 func (p *parser) newInExpr(l, r *ast.Node, inOp Item) *ast.Node {
 	return ast.WrapInExpr(&ast.InExpr{
 		LHS:   l,
+		Op:    "in",
 		RHS:   r,
 		OpPos: p.posCache.LnCol(inOp.Pos),
 	})

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1702,7 +1702,7 @@ x[
 x[a]
 x[
 	a]
-
+x in pt_kvs_keys(fields=false,tags=true)
 cALl(
 	a, v,
 	c )


### PR DESCRIPTION
问题#56 
$\qquad$测试’add_key("t5", x in function(tags=false))‘发现in语法解析没有问题，是函数调用的问题
$\qquad$发现in语法解析时缺省了in 如‘x in [1,2,3]' 解析为 x [1,2,3]
原因：`newInExpr`函数结构体没有写Op，加上就好了
