### PR TITLE
fix runtimev2 signal propagation

### DIFF
--- a/pkg/engine/runtimev2/runtime.go
+++ b/pkg/engine/runtimev2/runtime.go
@@ -21,6 +21,7 @@ type Script struct {
 
 func (s *Script) Run(signal Signal, opt ...Opt) *errchain.PlError {
 	task := NewTask(s.Name, s.Fn)
+	task.signal = signal
 	for _, o := range opt {
 		if o != nil {
 			o(task)

--- a/pkg/engine/runtimev2/runtime_test.go
+++ b/pkg/engine/runtimev2/runtime_test.go
@@ -1,0 +1,43 @@
+package runtimev2
+
+import (
+	"testing"
+
+	"github.com/GuanceCloud/platypus/pkg/ast"
+	"github.com/stretchr/testify/require"
+)
+
+type testSignal struct {
+	exit bool
+}
+
+func (s *testSignal) ExitSignal() bool {
+	return s.exit
+}
+
+func TestScriptRunSetsSignal(t *testing.T) {
+	sig := &testSignal{}
+	script := &Script{Name: "test.p"}
+
+	var got Signal
+	err := script.Run(sig, func(task *Task) {
+		got = task.signal
+	})
+
+	require.Nil(t, err)
+	require.Same(t, sig, got)
+}
+
+func TestRunForStmtStopsWhenSignalSet(t *testing.T) {
+	ctx := NewTask("test.p", nil)
+	ctx.signal = &testSignal{exit: true}
+
+	err := RunStmts(ctx, ast.Stmts{
+		ast.WrapForStmt(&ast.ForStmt{
+			Body: &ast.BlockStmt{},
+		}),
+	})
+
+	require.Nil(t, err)
+	require.True(t, ctx.procExit)
+}


### PR DESCRIPTION
## What changed

- Wire the `signal` argument passed to `runtimev2.Script.Run` into the runtime task.
- Add coverage that verifies `Script.Run` preserves the signal and loop execution exits when the signal is set.

## Why

`runtimev2.Script.Run` accepted a `Signal` but never assigned it to the task, so callers such as arbiter could pass a cancellation signal without the runtime observing it. Long-running scripts could keep executing even after the caller timeout context had expired.

## Validation

- `go test -count=1 ./pkg/engine/runtimev2 ./pkg/engine/runtime`
- `go test -count=1 ./pkg/engine/...`